### PR TITLE
Update Program.cs

### DIFF
--- a/iisGeolocate/Program.cs
+++ b/iisGeolocate/Program.cs
@@ -145,7 +145,7 @@ namespace iisGeolocate
                         if (uniqueIps.Count > 0)
                         {
                             _logger.Info($"Unique IPs found so far: {uniqueIps.Count:N0}");
-                            return;
+                            //return;
                         }
 
                         using (var instream = File.OpenText(file))
@@ -153,6 +153,7 @@ namespace iisGeolocate
                             var csv = new CsvReader(instream);
                             csv.Configuration.Delimiter = " ";
                             csv.Configuration.HasHeaderRecord = false;
+                            csv.Configuration.BadDataFound = null;
 
                             csv.Read();
 
@@ -207,6 +208,11 @@ namespace iisGeolocate
                             while (csv.Read())
                             {
                                 rawLine = csv.Context.RawRecord.Trim();
+                                
+                                if (rawLine.StartsWith("#"))
+                                {
+                                    continue;
+                                }
 
                                 currentRecord = csv.GetRecord<dynamic>();
 


### PR DESCRIPTION
remove return that jumped out of loop when moving to next file
added some basic bad data handling for csvreader
when reading data, skip lines starting with # in middle of data.  happens on server reboot, headers put back in log